### PR TITLE
Add login page and authentication context

### DIFF
--- a/src/Pages/App/App.js
+++ b/src/Pages/App/App.js
@@ -9,6 +9,7 @@ import Display from "../Display/Display";
 import FormationDetailPage from "../Formations/formationDetail";
 import FormationPage from "../Formations/formations";
 import PresentationPage from "../MainPage/MainPage";
+import LoginPage from "../Login/login";
 import NavigationBar from "../../components/NavigationBar/NavigationBar";
 import FooterSection from "../../components/Footer/footer";
 
@@ -35,6 +36,7 @@ function App() {
                                 <Route path="/cursus/:id" element={<CursusPage />} />
                                 <Route path="/about" element={<AboutUs />} />
                                 <Route path="/formations" element={<FormationPage />} />
+                                <Route path="/login" element={<LoginPage />} />
                                 <Route path="/display" element={<Display />} />
                         </Routes>
                         <FooterSection />

--- a/src/Pages/Login/login.jsx
+++ b/src/Pages/Login/login.jsx
@@ -1,0 +1,91 @@
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { Button } from "../../components/ui/button";
+import { useAuth } from "../../hooks/useAuth";
+
+function LoginPage() {
+        const navigate = useNavigate();
+        const { login, user } = useAuth();
+        const [credentials, setCredentials] = useState({ username: "", password: "" });
+        const [error, setError] = useState("");
+
+        useEffect(() => {
+                if (user) {
+                        navigate("/display", { replace: true });
+                }
+        }, [user, navigate]);
+
+        const handleChange = (event) => {
+                const { name, value } = event.target;
+                setCredentials((previous) => ({ ...previous, [name]: value }));
+        };
+
+        const handleSubmit = (event) => {
+                event.preventDefault();
+                const result = login(credentials.username, credentials.password);
+
+                if (result.success) {
+                        setError("");
+                        navigate("/display");
+                } else {
+                        setError(result.error ?? "Identifiants invalides.");
+                }
+        };
+
+        return (
+                <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-[#0F1C2E] to-[#1A2B3C] text-white px-4">
+                        <form
+                                onSubmit={handleSubmit}
+                                className="w-full max-w-md bg-[#15253A] bg-opacity-80 backdrop-blur rounded-2xl shadow-xl p-8 space-y-6"
+                        >
+                                <div>
+                                        <h1 className="text-3xl font-bold text-center">Connexion</h1>
+                                        <p className="text-center text-[#AEEFFF] mt-2">
+                                                Accédez à votre tableau Monday en renseignant vos identifiants.
+                                        </p>
+                                </div>
+
+                                <label className="block">
+                                        <span className="text-sm font-medium text-[#AEEFFF]">Identifiant</span>
+                                        <input
+                                                type="text"
+                                                name="username"
+                                                value={credentials.username}
+                                                onChange={handleChange}
+                                                className="mt-1 w-full px-4 py-3 rounded-lg bg-[#0F1C2E] border border-[#2C3E50] focus:outline-none focus:ring-2 focus:ring-[#AEEFFF]"
+                                                placeholder="Votre identifiant"
+                                                autoComplete="username"
+                                                required
+                                        />
+                                </label>
+
+                                <label className="block">
+                                        <span className="text-sm font-medium text-[#AEEFFF]">Mot de passe</span>
+                                        <input
+                                                type="password"
+                                                name="password"
+                                                value={credentials.password}
+                                                onChange={handleChange}
+                                                className="mt-1 w-full px-4 py-3 rounded-lg bg-[#0F1C2E] border border-[#2C3E50] focus:outline-none focus:ring-2 focus:ring-[#AEEFFF]"
+                                                placeholder="Votre mot de passe"
+                                                autoComplete="current-password"
+                                                required
+                                        />
+                                </label>
+
+                                {error ? (
+                                        <p className="text-sm text-red-400 text-center" role="alert">
+                                                {error}
+                                        </p>
+                                ) : null}
+
+                                <Button type="submit" className="w-full bg-[#AEEFFF] text-[#0F1C2E] font-semibold hover:bg-[#E8F9FF]">
+                                        Se connecter
+                                </Button>
+                        </form>
+                </div>
+        );
+}
+
+export default LoginPage;

--- a/src/components/NavigationBar/NavigationBar.jsx
+++ b/src/components/NavigationBar/NavigationBar.jsx
@@ -1,11 +1,12 @@
 import { motion } from "framer-motion";
 import { Button } from "../ui/button";
 import logo from "../../assets/logo.png";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useState, useEffect } from "react";
 
 function NavigationBar() {
-	const [isScrolled, setIsScrolled] = useState(false);
+        const navigate = useNavigate();
+        const [isScrolled, setIsScrolled] = useState(false);
 
 	useEffect(() => {
 		const handleScroll = () => {
@@ -65,7 +66,7 @@ function NavigationBar() {
 			</ul>
                         <Button
                                 className="bg-[#AEEFFF] text-[#1A2B3C] px-6 py-2 rounded-xl hover:bg-[#E8F9FF] transition"
-                                onClick={() => window.location.href = "/display"}
+                                onClick={() => navigate("/login")}
                         >
                                 Tableau Monday
                         </Button>

--- a/src/data/users.js
+++ b/src/data/users.js
@@ -1,0 +1,10 @@
+export const authorizedUsers = [
+        {
+                username: "admin",
+                password: "password123",
+        },
+        {
+                username: "manager",
+                password: "monday!2024",
+        },
+];

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,0 +1,80 @@
+import { createContext, useContext, useState, useEffect, useMemo, useCallback } from "react";
+
+import { authorizedUsers } from "../data/users";
+
+const AuthContext = createContext(undefined);
+const AUTH_STORAGE_KEY = "skylonis-auth-user";
+
+const readStoredUser = () => {
+        if (typeof window === "undefined") {
+                return null;
+        }
+
+        const storedValue = window.localStorage.getItem(AUTH_STORAGE_KEY);
+
+        if (!storedValue) {
+                return null;
+        }
+
+        try {
+                return JSON.parse(storedValue);
+        } catch (error) {
+                console.warn("Impossible de lire l'utilisateur stocké", error);
+                return null;
+        }
+};
+
+export function AuthProvider({ children }) {
+        const [user, setUser] = useState(() => readStoredUser());
+
+        useEffect(() => {
+                if (typeof window === "undefined") {
+                        return;
+                }
+
+                if (user) {
+                        window.localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(user));
+                } else {
+                        window.localStorage.removeItem(AUTH_STORAGE_KEY);
+                }
+        }, [user]);
+
+        const login = useCallback((username, password) => {
+                const match = authorizedUsers.find(
+                        (allowedUser) => allowedUser.username === username && allowedUser.password === password,
+                );
+
+                if (match) {
+                        const authenticatedUser = { username: match.username };
+                        setUser(authenticatedUser);
+                        return { success: true, user: authenticatedUser };
+                }
+
+                return { success: false, error: "Identifiants incorrects. Veuillez réessayer." };
+        }, []);
+
+        const logout = useCallback(() => {
+                setUser(null);
+        }, []);
+
+        const value = useMemo(
+                () => ({
+                        user,
+                        login,
+                        logout,
+                }),
+                [user, login, logout],
+        );
+
+        return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+        const context = useContext(AuthContext);
+
+        if (!context) {
+                throw new Error("useAuth doit être utilisé à l'intérieur d'un AuthProvider");
+        }
+
+        return context;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './Pages/App/App';
+import { AuthProvider } from './hooks/useAuth';
 
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-        <App />
+        <AuthProvider>
+                <App />
+        </AuthProvider>
 );


### PR DESCRIPTION
## Summary
- add a dedicated login page with a controlled credentials form and simple error handling
- introduce a reusable auth context backed by a static list of allowed users and localStorage persistence
- register the login route in the router and update the navigation CTA to point to it

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_b_68d7018e8ff4832aa6dbbf375116c279