### PR TITLE
feat: personalize Monday display per authenticated user

### DIFF
--- a/src/Pages/Login/login.jsx
+++ b/src/Pages/Login/login.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 
 import { Button } from "../../components/ui/button";
 import { useAuth } from "../../hooks/useAuth";
+import { authorizedUsers } from "../../data/users";
 
 function LoginPage() {
         const navigate = useNavigate();
@@ -23,7 +24,20 @@ function LoginPage() {
 
         const handleSubmit = (event) => {
                 event.preventDefault();
-                const result = login(credentials.username, credentials.password);
+                const matchedUser = authorizedUsers.find(
+                        (candidate) =>
+                                candidate.username === credentials.username &&
+                                candidate.password === credentials.password,
+                );
+
+                const boardOverrides = matchedUser
+                        ? {
+                                  boardUrl: matchedUser.boardUrl,
+                                  boardLabel: matchedUser.boardLabel,
+                          }
+                        : undefined;
+
+                const result = login(credentials.username, credentials.password, boardOverrides);
 
                 if (result.success) {
                         setError("");

--- a/src/data/users.js
+++ b/src/data/users.js
@@ -2,9 +2,13 @@ export const authorizedUsers = [
         {
                 username: "admin",
                 password: "password123",
+                boardUrl: "https://embed.monday.com/embed/boards/4201786698",
+                boardLabel: "Pilotage - Admin",
         },
         {
                 username: "manager",
                 password: "monday!2024",
+                boardUrl: "https://embed.monday.com/embed/boards/5112768042?view=timeline",
+                boardLabel: "Suivi - Manager",
         },
 ];

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -39,13 +39,17 @@ export function AuthProvider({ children }) {
                 }
         }, [user]);
 
-        const login = useCallback((username, password) => {
+        const login = useCallback((username, password, overrides = {}) => {
                 const match = authorizedUsers.find(
                         (allowedUser) => allowedUser.username === username && allowedUser.password === password,
                 );
 
                 if (match) {
-                        const authenticatedUser = { username: match.username };
+                        const authenticatedUser = {
+                                username: match.username,
+                                boardUrl: overrides.boardUrl ?? match.boardUrl ?? null,
+                                boardLabel: overrides.boardLabel ?? match.boardLabel ?? null,
+                        };
                         setUser(authenticatedUser);
                         return { success: true, user: authenticatedUser };
                 }


### PR DESCRIPTION
## Summary
- map each authorized user to their dedicated Monday board URL and label in the auth context
- pass the mapped board data through login so authenticated state persists the Monday iframe to show
- update the display page to prefer the user board, fall back to configuration otherwise, and prompt sign-in when unauthenticated

## Testing
- npm run test -- --watchAll=false *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_68d703303d24832a9444a6fd1d13c633