### PR TITLE
Restore classic display layout with logout control

### DIFF
--- a/src/Pages/Display/Display.css
+++ b/src/Pages/Display/Display.css
@@ -1,8 +1,30 @@
 .display-layout {
+        position: relative;
         display: flex;
         height: 100vh;
         background: linear-gradient(135deg, #0f172a, #1e293b);
         color: #f8fafc;
+}
+
+.display-logout-button {
+        position: absolute;
+        top: 1.5rem;
+        right: 1.5rem;
+        padding: 0.6rem 1.25rem;
+        border-radius: 9999px;
+        border: 1px solid rgba(56, 189, 248, 0.8);
+        background: rgba(15, 23, 42, 0.85);
+        color: #e0f2fe;
+        font-size: 0.9rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all 0.2s ease;
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.35);
+}
+
+.display-logout-button:hover {
+        background: rgba(56, 189, 248, 0.2);
+        transform: translateY(-1px);
 }
 
 .display-sidebar {
@@ -117,6 +139,11 @@
 @media (max-width: 960px) {
         .display-layout {
                 flex-direction: column;
+        }
+
+        .display-logout-button {
+                top: 1rem;
+                right: 1rem;
         }
 
         .display-sidebar {

--- a/src/Pages/Display/Display.jsx
+++ b/src/Pages/Display/Display.jsx
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import axios from "axios";
 import { motion } from "framer-motion";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { MdOutlineDashboardCustomize } from "react-icons/md";
 import { unwrapArray } from "../../services/catalogAdapters";
 import { useAuth } from "../../hooks/useAuth";
@@ -57,7 +57,8 @@ const FALLBACK_BOARDS = [
 ];
 
 const Display = () => {
-        const { user: currentUser } = useAuth();
+        const navigate = useNavigate();
+        const { user: currentUser, logout } = useAuth();
         const userBoard = useMemo(() => {
                 if (!currentUser?.boardUrl) {
                         return null;
@@ -74,6 +75,11 @@ const Display = () => {
         const [loading, setLoading] = useState(true);
         const [statusMessage, setStatusMessage] = useState("");
         const [error, setError] = useState("");
+
+        const handleLogout = useCallback(() => {
+                logout();
+                navigate("/login");
+        }, [logout, navigate]);
 
         useEffect(() => {
                 if (!currentUser) {
@@ -192,6 +198,9 @@ const Display = () => {
 
         return (
                 <div className="display-layout">
+                        <button type="button" className="display-logout-button" onClick={handleLogout}>
+                                Se déconnecter
+                        </button>
                         {!userBoard && (
                                 <aside className="display-sidebar">
                                         <h2>Tableaux Monday</h2>


### PR DESCRIPTION
## Summary
- revert the Display page styling and layout to its previous structure
- add a fixed logout button that signs out the user and redirects back to the login screen

## Testing
- npm run build *(fails: build process hangs while creating the optimized bundle in this container)*

------
https://chatgpt.com/codex/tasks/task_b_68d7a0f0f41c832a8c56b675cfbda882